### PR TITLE
Set MSRV as 1.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lifehash"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.82"
 description = "A Lifehash implementation in Rust"
 license = "Apache-2.0"
 


### PR DESCRIPTION
1.82 is the first release stabilizing floating point arithmetic in `const fn`, which is used in the package.